### PR TITLE
Remove AMR and refine GLM implementation

### DIFF
--- a/grid.cpp
+++ b/grid.cpp
@@ -3,11 +3,13 @@
 #include <omp.h>
 #include <iostream>
 
-int refinement_count = 0;
-
 Grid::Grid(int nx_,int ny_,double dx_,double dy_,double x0_,double y0_)
     : nx(nx_),ny(ny_),dx(dx_),dy(dy_),x0(x0_),y0(y0_),
-      data(nx_, std::vector<double>(ny_,0.0)) {}
+      data(nx_, std::vector<double>(ny_,0.0))
+{
+    if(nx_ < 3 || ny_ < 3)
+        throw std::invalid_argument("Grid size must be at least 3x3");
+}
 
 void Grid::fill(double v){
 #pragma omp parallel for collapse(2)
@@ -16,84 +18,15 @@ void Grid::fill(double v){
             data[i][j]=v;
 }
 
-AMRGrid::AMRGrid(int base_nx,int base_ny,double Lx,double Ly,int max_level_)
-    : max_level(max_level_)
-{
-    levels.emplace_back(base_nx,base_ny,Lx/(base_nx-1),Ly/(base_ny-1),0.0,0.0);
-}
-
-void AMRGrid::refine(int level, int start_x, int start_y, int coarse_nx_patch, int coarse_ny_patch) {
-    if(level >= max_level || refinement_count >= MAX_REFINEMENTS) return;
-    
-    // Ensure the patch stays within bounds
-    start_x = std::max(0, std::min(start_x, levels[level].nx - coarse_nx_patch));
-    start_y = std::max(0, std::min(start_y, levels[level].ny - coarse_ny_patch));
-    
-    // Fine grid has 2x resolution
-    int fine_nx = coarse_nx_patch * 2 + 1;  // +1 for proper overlap
-    int fine_ny = coarse_ny_patch * 2 + 1;
-    
-    double fine_dx = levels[level].dx / 2.0;
-    double fine_dy = levels[level].dy / 2.0;
-    
-    // Align with coarse cell edges
-    double x0 = levels[level].x0 + start_x * levels[level].dx;
-    double y0 = levels[level].y0 + start_y * levels[level].dy;
-    
-    std::cout << "[AMR] refine level " << level << " at (" << start_x << "," << start_y 
-              << ") covering " << coarse_nx_patch << "x" << coarse_ny_patch << " coarse cells\n";
-    
-    levels.emplace_back(fine_nx, fine_ny, fine_dx, fine_dy, x0, y0);
-    ++refinement_count;
-    
-    // Proper interpolation
-    Grid& fine = levels.back();
-    Grid& coarse = levels[level];
-    
-    #pragma omp parallel for collapse(2)
-    for(int i = 0; i < fine_nx; ++i) {
-        for(int j = 0; j < fine_ny; ++j) {
-            // Map fine grid point to coarse grid
-            double x_fine = x0 + i * fine_dx;
-            double y_fine = y0 + j * fine_dy;
-            
-            // Find coarse cell indices
-            double ci_real = (x_fine - coarse.x0) / coarse.dx;
-            double cj_real = (y_fine - coarse.y0) / coarse.dy;
-            
-            int ci = (int)ci_real;
-            int cj = (int)cj_real;
-            
-            // Bilinear interpolation
-            if(ci >= 0 && ci < coarse.nx-1 && cj >= 0 && cj < coarse.ny-1) {
-                double fx = ci_real - ci;
-                double fy = cj_real - cj;
-                
-                fine.data[i][j] = (1-fx)*(1-fy)*coarse.data[ci][cj] +
-                                  fx*(1-fy)*coarse.data[ci+1][cj] +
-                                  (1-fx)*fy*coarse.data[ci][cj+1] +
-                                  fx*fy*coarse.data[ci+1][cj+1];
-            } else {
-                // Boundary handling
-                ci = std::max(0, std::min(ci, coarse.nx-1));
-                cj = std::max(0, std::min(cj, coarse.ny-1));
-                fine.data[i][j] = coarse.data[ci][cj];
-            }
-        }
-    }
-}
-
-bool AMRGrid::needs_refinement(const Grid& g,int i,int j,double thres){
-    if(i<=0||i>=g.nx-1||j<=0||j>=g.ny-1) return false;
-    double gx=std::fabs(g.data[i+1][j]-g.data[i-1][j])/(2*g.dx);
-    double gy=std::fabs(g.data[i][j+1]-g.data[i][j-1])/(2*g.dy);
-    return (gx+gy)>thres;
-}
 
 FlowField::FlowField(int nx,int ny,double dx,double dy,double x0,double y0)
     : rho(nx,ny,dx,dy,x0,y0), u(nx,ny,dx,dy,x0,y0), v(nx,ny,dx,dy,x0,y0),
       p(nx,ny,dx,dy,x0,y0), e(nx,ny,dx,dy,x0,y0),
-      bx(nx,ny,dx,dy,x0,y0), by(nx,ny,dx,dy,x0,y0), psi(nx,ny,dx,dy,x0,y0) {}
+      bx(nx,ny,dx,dy,x0,y0), by(nx,ny,dx,dy,x0,y0), psi(nx,ny,dx,dy,x0,y0)
+{
+    if(nx < 3 || ny < 3)
+        throw std::invalid_argument("FlowField grid must be at least 3x3");
+}
 
 FlowField::FlowField(const Grid& g)
     : FlowField(g.nx,g.ny,g.dx,g.dy,g.x0,g.y0) {}

--- a/grid.hpp
+++ b/grid.hpp
@@ -2,10 +2,8 @@
 #include <vector>
 #include <cmath>
 #include <string>
+#include <stdexcept>
 
-// Maximum number of AMR patches allowed in a single run
-constexpr int MAX_REFINEMENTS = 5;
-extern int refinement_count;
 
 /**
  * Lightweight 2‑D uniformly‑spaced scalar field.
@@ -21,14 +19,6 @@ public:
     void fill(double v);
 };
 
-class AMRGrid {
-public:
-    std::vector<Grid> levels;
-    int max_level;
-    AMRGrid(int base_nx, int base_ny, double Lx, double Ly, int max_level=1);
-    void refine(int level, int start_x, int start_y, int fine_nx, int fine_ny);
-    bool needs_refinement(const Grid& g, int i,int j,double threshold);
-};
 
 struct FlowField {
     Grid rho,u,v,p,e;

--- a/io.cpp
+++ b/io.cpp
@@ -21,4 +21,5 @@ void save_flow_MHD(const FlowField& flow,const std::string& dir,int step){
     dump_scalar(flow.e,   prefix+"e_"+std::to_string(step)+".csv");
     dump_scalar(flow.bx,  prefix+"bx_"+std::to_string(step)+".csv");
     dump_scalar(flow.by,  prefix+"by_"+std::to_string(step)+".csv");
+    dump_scalar(flow.psi, prefix+"psi_"+std::to_string(step)+".csv");
 }

--- a/main.cpp
+++ b/main.cpp
@@ -6,7 +6,6 @@
 #include <chrono>
 #include <iostream>
 #include <iomanip>
-#include <vector>
 
 static std::string prepare_output_dir(){
     namespace fs = std::filesystem;
@@ -28,10 +27,8 @@ int main(){
 
     std::string out_dir = prepare_output_dir();
 
-    AMRGrid amr(nx,ny,Lx,Ly,1);
-    std::vector<FlowField> flows;
-    flows.emplace_back(nx,ny,dx,dy);
-    initialize_orszag_tang(flows[0]);
+    FlowField flow(nx,ny,dx,dy);
+    initialize_orszag_tang(flow);
     //initialize_MHD_disk(flows[0]); // deterministic seed default
     //add_divergence_error(flows[0], 0.1);
 
@@ -39,14 +36,14 @@ int main(){
     auto t0=std::chrono::high_resolution_clock::now();
     for(int step=0; step<=max_steps; ++step){
         // Use dynamic CFL-based timestep from the current flow state
-        double dt = compute_cfl_timestep(flows[0]);
+        double dt = compute_cfl_timestep(flow);
 
-        solve_MHD(amr,flows,dt,nu,0,0.0);
+        solve_MHD(flow, dt, nu);
 
         if(step%output_every==0){
             std::cout << "step "<< std::setw(4) << step
                       << " dt="<<dt<<"\n";
-            save_flow_MHD(flows[0],out_dir,step);
+            save_flow_MHD(flow,out_dir,step);
         }
     }
     auto t1=std::chrono::high_resolution_clock::now();

--- a/solver.hpp
+++ b/solver.hpp
@@ -1,7 +1,6 @@
 #pragma once
 #include "grid.hpp"
-#include <vector>
-void solve_MHD(AMRGrid& amr, std::vector<FlowField>& flows,double dt,double nu,int max_iter,double tol);
+void solve_MHD(FlowField& flow, double dt, double nu);
 // Estimate stable timestep based on CFL condition
 double compute_cfl_timestep(const FlowField& flow, double cfl_number = 0.4);
 std::pair<double, double> compute_divergence_errors(const FlowField& flow);  // Add this line


### PR DESCRIPTION
## Summary
- strip unused AMR infrastructure
- unify `gamma_gas` with physics setup
- limit CFL step with GLM wave speed
- clean magnetic divergence on boundaries
- output the `psi` field for diagnostics
- basic argument checking for grid constructors

## Testing
- `g++ -std=c++17 -O2 main.cpp grid.cpp physics.cpp solver.cpp io.cpp -fopenmp -o mhd`
- `./mhd 2>&1 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684b4bb58d20832eb4ac79f2a0d369b7