### PR TITLE
Add flow animation to run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ To build the executable, run the provided `compile.sh` script or use the followi
 ```bash
 g++ main.cpp grid.cpp physics.cpp solver.cpp io.cpp -std=c++17 -O2 -fopenmp -o mhd_solver
 ```
+
+To run the solver and generate analysis plots, execute:
+
+```bash
+bash run.sh
+```
+
+The script builds `mhd_solver` if needed and runs the simulation. Output CSV
+files are written to a new `Result` directory. If a previous `Result` folder
+exists it is renamed with a timestamp. After validating the output,
+`analysis_summary.py` generates summary plots and `plot_flow.py` creates an
+animation of the flow field. All console output is stored in `solver.log`.

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Compile and run the solver, then execute Python analysis scripts.
+set -e
+
+# Build solver if needed
+if [ ! -x mhd_solver ]; then
+    bash compile.sh
+fi
+
+# Run solver and capture output
+./mhd_solver | tee solver.log
+
+# Verify that CSV output files exist
+if ! ls Result/out_*.csv >/dev/null 2>&1; then
+    echo "No output generated in Result/" >&2
+    exit 1
+fi
+
+# Run analysis scripts
+python3 analysis_summary.py | tee -a solver.log
+python3 plot_flow.py | tee -a solver.log
+echo "Results stored in Result/ (previous runs are timestamped)."


### PR DESCRIPTION
## Summary
- enhance `run.sh` to generate `flow_animation.mp4` and report result location
- update usage docs in the README

## Testing
- `bash compile.sh`
- `./mhd_solver | head -n 5`
- `python3 analysis_summary.py 2>&1 | head -n 5` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684b57ab995c832ebe1b39210bae1e8f