### PR TITLE
Improve solver stability and output handling

### DIFF
--- a/solver.hpp
+++ b/solver.hpp
@@ -2,5 +2,5 @@
 #include "grid.hpp"
 void solve_MHD(FlowField& flow, double dt, double nu);
 // Estimate stable timestep based on CFL condition
-double compute_cfl_timestep(const FlowField& flow, double cfl_number = 0.4);
+double compute_cfl_timestep(const FlowField& flow, double cfl_number = 0.2);
 std::pair<double, double> compute_divergence_errors(const FlowField& flow);  // Add this line


### PR DESCRIPTION
## Summary
- reduce CFL default and enforce upper limit on timestep
- ensure total energy remains positive
- keep `psi` periodic at boundaries
- tweak GLM and diffusivity constants

## Testing
- `bash compile.sh`
- `bash run.sh` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684b5a52ac7c832ebd8198f970a515db